### PR TITLE
Fixed setting xades signature policy uri when parsing signature structure

### DIFF
--- a/dss-spi/src/main/java/eu/europa/esig/dss/XPathQueryHolder.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/XPathQueryHolder.java
@@ -113,6 +113,7 @@ public class XPathQueryHolder implements Serializable {
 	public String XPATH__POLICY_ID = "./xades:SignaturePolicyId/xades:SigPolicyId/xades:Identifier";
 	public String XPATH__POLICY_DIGEST_METHOD = "./xades:SignaturePolicyId/xades:SigPolicyHash/ds:DigestMethod/@Algorithm";
 	public String XPATH__POLICY_DIGEST_VALUE = "./xades:SignaturePolicyId/xades:SigPolicyHash/ds:DigestValue";
+	public String XPATH__POLICY_SPURI = "./xades:SignaturePolicyId/xades:SigPolicyQualifiers/xades:SigPolicyQualifier/xades:SPURI";
 	public String XPATH__INCLUDE = "./xades:Include";
 
 	public String XPATH__X509_ISSUER_NAME = "./xades:IssuerSerial/ds:X509IssuerName";

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
@@ -633,6 +633,10 @@ public class XAdESSignature extends DefaultAdvancedSignature {
 				final Element policyDigestValue = DSSXMLUtils.getElement(policyIdentifier, xPathQueryHolder.XPATH__POLICY_DIGEST_VALUE);
 				final String digestValue = policyDigestValue.getTextContent().trim();
 				signaturePolicy.setDigestValue(digestValue);
+				final Element policyUrl = DSSXMLUtils.getElement(policyIdentifier, xPathQueryHolder.XPATH__POLICY_SPURI);
+				if (policyUrl != null) {
+					signaturePolicy.setUrl(policyUrl.getTextContent().trim());
+				}
 				return signaturePolicy;
 			} else {
 				// Implicit policy

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/validation/XAdESValidationTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/validation/XAdESValidationTest.java
@@ -1,0 +1,56 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ *
+ * This file is part of the "DSS - Digital Signature Services" project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.validation;
+
+import eu.europa.esig.dss.DigestAlgorithm;
+import eu.europa.esig.dss.FileDocument;
+import eu.europa.esig.dss.validation.AdvancedSignature;
+import eu.europa.esig.dss.validation.SignedDocumentValidator;
+import eu.europa.esig.dss.x509.SignaturePolicy;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class XAdESValidationTest {
+
+    private static final String POLICY_ID = "urn:oid:1.3.6.1.4.1.10015.1000.3.2.1";
+    private static final String POLICY_URL = "http://spuri.test";
+    private static final String POLICY_DIGEST_VALUE = "3Tl1oILSvOAWomdI9VeWV6IA/32eSXRUri9kPEz1IVs=";
+
+    @Test
+    public void validatedXadesSignatureShouldContainPolicyParameters() throws Exception {
+        XAdESSignature xadesSignature = openXadesSignature("src/test/resources/validation/valid-xades.xml");
+        SignaturePolicy policy = xadesSignature.getPolicyId();
+        assertEquals(POLICY_ID, policy.getIdentifier());
+        assertEquals(DigestAlgorithm.SHA256, policy.getDigestAlgorithm());
+        assertEquals(POLICY_DIGEST_VALUE, policy.getDigestValue());
+        assertEquals(POLICY_URL, policy.getUrl());
+    }
+
+    private XAdESSignature openXadesSignature(String documentPath) {
+        SignedDocumentValidator validator = SignedDocumentValidator.fromDocument(new FileDocument(new File(documentPath)));
+        List<AdvancedSignature> signatureList = validator.getSignatures();
+        return (XAdESSignature) signatureList.get(0);
+    }
+}

--- a/dss-xades/src/test/resources/validation/valid-xades.xml
+++ b/dss-xades/src/test/resources/validation/valid-xades.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ds:Signature Id="id-93ef2bbbf61754c3735a8f0d34aff556" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference Id="r-id-1" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="#o-id-1">
+            <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#base64"/>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <ds:DigestValue>68ArneI9PhOBJytj5sP/zEewR2DkFObxewMY1wiUvak=</ds:DigestValue>
+        </ds:Reference>
+        <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#xades-id-93ef2bbbf61754c3735a8f0d34aff556">
+            <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <ds:DigestValue>NZpI+dLFqcaP/fZH0uiNtsb4ep88PoPCIvEcUODdP94=</ds:DigestValue>
+        </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue Id="value-id-93ef2bbbf61754c3735a8f0d34aff556">CDl7OU9vewbpQ8Sx/3GxYxPyn9Ez7bM3SA0MQW9CvjK0dE3HxxqEFME7AjWKggF3jXVmpLZeHWy3lmfoxARjsSCQxkfYTWJ7sl8nl0Lzc6MZd6FzlkVW+cip1D5o3uUj7Z/my3GN70dI8PAv9uN7TTuACkqKZqNsI6ayS+NlMowuYZ5L5eoLXkW0syuGl1Bb1wTyIKrhKCHANzeJFIZDlxKr14rgLMOvRooyAP81t7zt3lYzQQAes9ux9jiF86bN8dWKFjuuhiZ2GOpwq3XF8+ljmYMZ+gNIOWLzBUgUDivzyp07XQVMZFOIfRFhJKvJos/p2/a2K3pTVLdV3iobfA==</ds:SignatureValue>
+    <ds:KeyInfo>
+        <ds:X509Data>
+            <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIGQPuhFUmiMA0GCSqGSIb3DQEBCwUAMDAxGzAZBgNVBAMMElJvb3RTZWxmU2lnbmVkRmFrZTERMA8GA1UECgwIRFNTLXRlc3QwHhcNMTUxMjA2MTAxODE1WhcNMTUxMjE3MTAxODE1WjAoMRMwEQYDVQQDDApTaWduZXJGYWtlMREwDwYDVQQKDAhEU1MtdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIvtBYO5bWl2tqDSzJplC6tZXSAsZnvoG0AWt3PAQ80Ff+Pt7e5UE4rK2IArcmT0EWFAqCpexUBn+pMO2JU9YLRBkjCaY4t9mVTOh/2GZdkKARjopvm8XMU01Jv1l/BjhmIZsSYELnqQzfwofdUmYu8VmMK5FbnbYi9+dxX0Kmnqw1L25s8aKDk8Mf3UIvB+/PJclg3ZgP4IQHEyGlhlsrBXGI09ZKSSs3aBJsSYtmaUKo8j1QJFSeYvbCmluU0VmYU7Q6QTBEe1l2h1eR0lNO1rFV0EGoPw44ronVPwMekydSOPy3XCeW/fuQa91bjrk0yvNOEslU7/28QFAZqA6pECAwEAAaMSMBAwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3DQEBCwUAA4IBAQBc4RCJaaCUe1KBSXZgHYk3zUAsAmhFIWc8mgHTwZx4k8RWkKlYML7CEmcM9HvK8nJROo14XW6ywuIR11RxNpbLABDVjZe4JPI0W298qIwbrHgbBCPuZ/GsfoUkbfAkbxYqK3fy0yCAPy08G3OtZbUz2R/GoZr/IViXOSroX6MvXaLMlxffaHijfyZKCMoL9Ba8gv19i+dwdqwGzaCvlQ4lhNTaW22+1j3De8p9tt8tq7vw7e3kzlpolpkvV8blNuXjWg3XfdYJoDZ5Xzad2b8w0skhxDt7jBoODPjmGoxLnUMd7c0DUGBaC3veNhtakz66j0STUTekz4F/Nu3KtWSN</ds:X509Certificate>
+            <ds:X509Certificate>MIIC8jCCAdqgAwIBAgIGN+NSoqhTMA0GCSqGSIb3DQEBCwUAMDAxGzAZBgNVBAMMElJvb3RTZWxmU2lnbmVkRmFrZTERMA8GA1UECgwIRFNTLXRlc3QwHhcNMTUxMjA2MTAxODE1WhcNMTUxMjE3MTAxODE1WjAwMRswGQYDVQQDDBJSb290U2VsZlNpZ25lZEZha2UxETAPBgNVBAoMCERTUy10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmWxfnxO6Gx1/Pa4j3cGkeuv0OP2OtCJKg4M+sbFwdnuAeO7Vz2Rsh0nWrKheL69tqaPa8Q6Gwwz6ph5FE50Qz8dkdd0y5U/g5S2qpHlB+1esmYvUoQYkIyDgzlA7jexU9g8VQwF5tkO5Y/36WuHiOoPCFqLK/RGa+O6ZKxCr32j+CVIbuWpPo5p0+DoXH/mBCdSSZPy96p7/3JbysBAy3q71OL9ouo8tv8O81uR6+qg/41pUEdjQmjUi+IL/qV9xAR37QtFk/6EUIscpJWZA0HoxX7xWbgSo+RMFq7i65W75BWkwFZnX8sScHjsIA4iFQyyV/aSlz/VEqLzk6x5DbwIDAQABoxIwEDAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQELBQADggEBACeL3m+RTsfWU6TCt4hvXuTSCpQyR+BpOjqbZqJYOA65XMjQEV3WLnyzpi2HrOCLBcOpPSt32JRBuX9fZSQO44G/qhAFkNAK9WbJGjxiJGgmKiF3y9t3swx5F/Mhx595rK42PgVHYP64flXnAAK/MKAkTuXRsHyi/w/BXjfjIJqhlrt6Nib0pn86c4M0uXyxxLJ0W4sMCmEMBpcai+Kl7fKyQQs+XakOjiJQ77UHl9CIsPxz9o4gXp0aO19HAEktEb0EA8vfWR+FYbCXeNX5+mIDNppIrYi+UQFsmQEeV8/VCZA9KyUK1CaiI7KwDPZ+VUzE2Te1B2ot2GlHSefPJks=</ds:X509Certificate>
+        </ds:X509Data>
+    </ds:KeyInfo>
+    <ds:Object>
+        <xades:QualifyingProperties Target="#id-93ef2bbbf61754c3735a8f0d34aff556" xmlns:xades="http://uri.etsi.org/01903/v1.3.2#">
+            <xades:SignedProperties Id="xades-id-93ef2bbbf61754c3735a8f0d34aff556">
+                <xades:SignedSignatureProperties>
+                    <xades:SigningTime>2015-12-07T10:18:15Z</xades:SigningTime>
+                    <xades:SigningCertificate>
+                        <xades:Cert>
+                            <xades:CertDigest>
+                                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                                <ds:DigestValue>R0Eqia4bK6mlipXwzHq8u3FOsloDu61pFcgbgNFp4UQ=</ds:DigestValue>
+                            </xades:CertDigest>
+                            <xades:IssuerSerial>
+                                <ds:X509IssuerName>O=DSS-test,CN=RootSelfSignedFake</ds:X509IssuerName>
+                                <ds:X509SerialNumber>71449483495842</ds:X509SerialNumber>
+                            </xades:IssuerSerial>
+                        </xades:Cert>
+                    </xades:SigningCertificate>
+                    <xades:SignaturePolicyIdentifier>
+                        <xades:SignaturePolicyId>
+                            <xades:SigPolicyId>
+                                <xades:Identifier Qualifier="OIDAsURN">urn:oid:1.3.6.1.4.1.10015.1000.3.2.1</xades:Identifier>
+                            </xades:SigPolicyId>
+                            <xades:SigPolicyHash>
+                                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                                <ds:DigestValue>3Tl1oILSvOAWomdI9VeWV6IA/32eSXRUri9kPEz1IVs=</ds:DigestValue>
+                            </xades:SigPolicyHash>
+                            <xades:SigPolicyQualifiers>
+                                <xades:SigPolicyQualifier>
+                                    <xades:SPURI>http://spuri.test</xades:SPURI>
+                                </xades:SigPolicyQualifier>
+                            </xades:SigPolicyQualifiers>
+                        </xades:SignaturePolicyId>
+                    </xades:SignaturePolicyIdentifier>
+                </xades:SignedSignatureProperties>
+                <xades:SignedDataObjectProperties>
+                    <xades:DataObjectFormat ObjectReference="#r-id-1">
+                        <xades:MimeType>text/xml</xades:MimeType>
+                    </xades:DataObjectFormat>
+                </xades:SignedDataObjectProperties>
+            </xades:SignedProperties>
+            <xades:UnsignedProperties>
+                <xades:UnsignedSignatureProperties>
+                    <xades:SignatureTimeStamp Id="TS-ff57e875-cf2e-4f99-b1b5-2572fe473bf3">
+                        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                        <xades:EncapsulatedTimeStamp Id="ETS-ff57e875-cf2e-4f99-b1b5-2572fe473bf3">MIAGCSqGSIb3DQEHAqCAMIACAQMxDzANBglghkgBZQMEAgEFADCABgsqhkiG9w0BCRABBKCAJIAEXjBcAgEBBgaCEoQ3hnowMTANBglghkgBZQMEAgEFAAQgnAFjlc/kdPRZVppL1plvMb/P8PccemfMmYVfaK5KpVUCAQEYDzIwMTUxMjA3MTAxODE2WgIIXQV9HHefsGEAAAAAAACggDCCAvUwggHdoAMCAQICBhOCGNgrkDANBgkqhkiG9w0BAQsFADAvMRowGAYDVQQDDBFSb290SXNzdWVyVFNQRmFrZTERMA8GA1UECgwIRFNTLXRlc3QwHhcNMTUxMjA2MTAxODE2WhcNMTUxMjE3MTAxODE2WjAsMRcwFQYDVQQDDA5Sb290U3ViamVjdFRTUDERMA8GA1UECgwIRFNTLXRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCy+hPrh/rV/YMOw4/VF44dwjOpAzzDlnK1oZBdxCNGoIoH4nwWvXlC+pNhmvs7CeFmWcL8aXB1Llr4oewuqqaZeoHLOc/UgLenqA534HjxEBJY54Ix/kiNikHnOWqJB3rn2YsiQvybvqipFvFernUs7UZ/e+Nn6Og528+NHCuCWDkPIdHWLXCOKRtMcnfjfMJbP4Exkd4JR2bYzj5fHknpN+bUSXQ1gktWM46zydKy+fIpP+ybr0HgOCkEd29Y6MQByMCMW5e96ZrSGKaLWOfNOppUYIwXdclhVv+MlkYaJ849uhwNkST6JbP3nr0dQxqihQx24Wx9U9rZVWVL7c6BAgMBAAGjGjAYMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMA0GCSqGSIb3DQEBCwUAA4IBAQCmPaCDlNtY6T8jfD7AqpnNURV3jZK/aAr9rzuWSMZOhJYFqgpQ4GqSi2hvCWg1B7J7VNV+SCHXYDHWMP0nHqDoNV+rPYVk8q8+s4tnXJ16xJIbIqVSlW3YrW1/OT8Jq0t+1FtgjJv14E4PxzLjZZvcoMaguIpR94q6TDcFtn/mQtyICBhxcFH4aMVok+x/HZy546aluoPpT2/GLlkz3g7y81qaQTnbroUtzDKfvpfIEOG03moDZT5wYHEikB7QCpvHiTBdwRFtt1krkV7+eZBEi2oRv7GwP09QwhBWofokaVTUl+Vv+uWAkRgR24RR0N+3ifuqd0hUhi4f8u/p/8axAAAxggIBMIIB/QIBATA5MC8xGjAYBgNVBAMMEVJvb3RJc3N1ZXJUU1BGYWtlMREwDwYDVQQKDAhEU1MtdGVzdAIGE4IY2CuQMA0GCWCGSAFlAwQCAQUAoIGYMBoGCSqGSIb3DQEJAzENBgsqhkiG9w0BCRABBDAcBgkqhkiG9w0BCQUxDxcNMTUxMjA3MTAxODE2WjArBgsqhkiG9w0BCRACDDEcMBowGDAWBBR1F4WsJKvCChnnVmkZT4xzz1DFWTAvBgkqhkiG9w0BCQQxIgQgrtqkX67uH3tKriCCwDa4Q2cXMDP/huXrfsem0Te76y0wDQYJKoZIhvcNAQEBBQAEggEAA/ShmghFw5in8DHUHf/WHOdanjDpZ+jJTJd6N2CHLPBhIrRhJAq1RrE5HowWQ0EWFyh+mLZAfLZJpplMwZeOyAzxxsg0t4c4cPrDJZPWAi5pxREu94BEwPj6Xz/6eS8vHdF3vyWuXexZngzCSBvSSD4yD4NuFfrCYSn4EVzSz6c/TcbhJxkHAKJ/GAuuWAnlGpeHIAT+4E8LPWITvTtwIDKMmG2SUz2p3kiWAlr8GSx0XExAgI/iTq1lqdqHzEuZFFw4WE7zF/IfXKj+umh6wDsh1fnZUknpB6HcoAdkqMsx6+AtyAx1VLuU/xYabaFefSNhNQTCZ4VvDeb8lqQeC6EAAAAAAAAA</xades:EncapsulatedTimeStamp>
+                    </xades:SignatureTimeStamp>
+                    <xades:CertificateValues>
+                        <xades:EncapsulatedX509Certificate>MIIC9TCCAd2gAwIBAgIGE4IY2CuQMA0GCSqGSIb3DQEBCwUAMC8xGjAYBgNVBAMMEVJvb3RJc3N1ZXJUU1BGYWtlMREwDwYDVQQKDAhEU1MtdGVzdDAeFw0xNTEyMDYxMDE4MTZaFw0xNTEyMTcxMDE4MTZaMCwxFzAVBgNVBAMMDlJvb3RTdWJqZWN0VFNQMREwDwYDVQQKDAhEU1MtdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALL6E+uH+tX9gw7Dj9UXjh3CM6kDPMOWcrWhkF3EI0agigfifBa9eUL6k2Ga+zsJ4WZZwvxpcHUuWvih7C6qppl6gcs5z9SAt6eoDnfgePEQEljngjH+SI2KQec5aokHeufZiyJC/Ju+qKkW8V6udSztRn9742fo6Dnbz40cK4JYOQ8h0dYtcI4pG0xyd+N8wls/gTGR3glHZtjOPl8eSek35tRJdDWCS1YzjrPJ0rL58ik/7JuvQeA4KQR3b1joxAHIwIxbl73pmtIYpotY5806mlRgjBd1yWFW/4yWRhonzj26HA2RJPols/eevR1DGqKFDHbhbH1T2tlVZUvtzoECAwEAAaMaMBgwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgwDQYJKoZIhvcNAQELBQADggEBAKY9oIOU21jpPyN8PsCqmc1RFXeNkr9oCv2vO5ZIxk6ElgWqClDgapKLaG8JaDUHsntU1X5IIddgMdYw/SceoOg1X6s9hWTyrz6zi2dcnXrEkhsipVKVbditbX85PwmrS37UW2CMm/XgTg/HMuNlm9ygxqC4ilH3irpMNwW2f+ZC3IgIGHFwUfhoxWiT7H8dnLnjpqW6g+lPb8YuWTPeDvLzWppBOduuhS3MMp++l8gQ4bTeagNlPnBgcSKQHtAKm8eJMF3BEW23WSuRXv55kESLahG/sbA/T1DCEFah+iRpVNSX5W/65YCRGBHbhFHQ37eJ+6p3SFSGLh/y7+n/xrE=</xades:EncapsulatedX509Certificate>
+                    </xades:CertificateValues>
+                </xades:UnsignedSignatureProperties>
+            </xades:UnsignedProperties>
+        </xades:QualifyingProperties>
+    </ds:Object>
+    <ds:Object Id="o-id-1">77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPGg6dGFibGUgeG1sbnM6aD0iaHR0cDovL3d3dy53My5vcmcvVFIvaHRtbDQvIj4KCTxoOnRyPgoJCTxoOnRkPkhlbGxvPC9oOnRkPgoJCTxoOnRkPldvcmxkPC9oOnRkPgoJPC9oOnRyPgo8L2g6dGFibGU+</ds:Object>
+</ds:Signature>


### PR DESCRIPTION
This modification fixes setting signature policy URI to XAdES signature object when parsing and validating XAdES signature structure.

The element that is included in parsing XAdES signature is `SPURI` within the signature policy ID element (all other elements are already being properly parsed):
`SignaturePolicyId/SigPolicyQualifiers/SigPolicyQualifier/SPURI`

``` xml
<xades:SignedSignatureProperties>
  <xades:SignaturePolicyIdentifier>
    <xades:SignaturePolicyId>
      <xades:SigPolicyQualifiers>
        <xades:SigPolicyQualifier>
          <xades:SPURI>http://spuri.test</xades:SPURI>
        </xades:SigPolicyQualifier>
      </xades:SigPolicyQualifiers>
    </xades:SignaturePolicyId>
  </xades:SignaturePolicyIdentifier>
</xades:SignedSignatureProperties>
```

As a TDD enthusiast, I added a unit test so it would be visible what got fixed. The following line of code tests the modification:

``` java
assertEquals(POLICY_URL, policy.getUrl());
```
