### PR TITLE
Fixed setting signature filename when creating an asic container

### DIFF
--- a/dss-asic/src/main/java/eu/europa/esig/dss/asic/signature/ASiCService.java
+++ b/dss-asic/src/main/java/eu/europa/esig/dss/asic/signature/ASiCService.java
@@ -602,20 +602,14 @@ public class ASiCService extends AbstractSignatureService<ASiCSignatureParameter
 	}
 
 	private String getSignatureFileName(final ASiCParameters asicParameters) {
+		if(StringUtils.isNotBlank(asicParameters.getSignatureFileName())) {
+			return META_INF + asicParameters.getSignatureFileName();
+		}
 		final boolean asice = isAsice(asicParameters);
-		final DSSDocument enclosedSignature = asicParameters.getEnclosedSignature();
 		if (isXAdESForm(asicParameters)) {
-			if (asice && (enclosedSignature != null)) {
-				return META_INF + asicParameters.getSignatureFileName();
-			} else {
-				return asice ? ZIP_ENTRY_ASICE_METAINF_XADES_SIGNATURE : ZIP_ENTRY_ASICS_METAINF_XADES_SIGNATURE;
-			}
+			return asice ? ZIP_ENTRY_ASICE_METAINF_XADES_SIGNATURE : ZIP_ENTRY_ASICS_METAINF_XADES_SIGNATURE;
 		} else if (isCAdESForm(asicParameters)) {
-			if (asice && (enclosedSignature != null)) {
-				return META_INF + asicParameters.getSignatureFileName();
-			} else {
-				return asice ? ZIP_ENTRY_ASICE_METAINF_CADES_SIGNATURE : ZIP_ENTRY_ASICS_METAINF_CADES_SIGNATURE;
-			}
+			return asice ? ZIP_ENTRY_ASICE_METAINF_CADES_SIGNATURE : ZIP_ENTRY_ASICS_METAINF_CADES_SIGNATURE;
 		} else {
 			throw new DSSException("ASiC signature form must be XAdES or CAdES!");
 		}

--- a/dss-asic/src/test/java/eu/europa/esig/dss/asic/signature/asice/ASiCESignatureFilenameTest.java
+++ b/dss-asic/src/test/java/eu/europa/esig/dss/asic/signature/asice/ASiCESignatureFilenameTest.java
@@ -1,0 +1,62 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ *
+ * This file is part of the "DSS - Digital Signature Services" project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.asic.signature.asice;
+
+import eu.europa.esig.dss.DSSDocument;
+import eu.europa.esig.dss.InMemoryDocument;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ASiCESignatureFilenameTest extends ASiCELevelBTest {
+
+    private DSSDocument documentToSign;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        documentToSign = new InMemoryDocument("Hello Wolrd !".getBytes(), "test.text");
+    }
+
+    @Override
+    public void signAndVerify() throws IOException {
+        String containerTemporaryPath = temporaryFolder.newFile().getPath();
+        getSignatureParameters().aSiC().setSignatureFileName("signatures2047.xml");
+        documentToSign = sign();
+        documentToSign.save(containerTemporaryPath);
+        ZipFile zip = new ZipFile(containerTemporaryPath);
+        assertNotNull("Signature file name is not correct", zip.getEntry("META-INF/signatures2047.xml"));
+    }
+
+    @Override
+    protected DSSDocument getDocumentToSign() {
+        return documentToSign;
+    }
+
+
+}


### PR DESCRIPTION
This modification fixes setting signature filename when creating asic containers. Previously the signatureFileName parameter was not used correctly.

There was also an exception when a container was signed twice. 

The following exceptions were thrown when a container was signed twice:

```
eu.europa.esig.dss.DSSException: java.util.zip.ZipException: duplicate entry: META-INF/null
    at eu.europa.esig.dss.asic.signature.ASiCService.createZipEntry(ASiCService.java:382)
    at eu.europa.esig.dss.asic.signature.ASiCService.buildXAdES(ASiCService.java:725)
    at eu.europa.esig.dss.asic.signature.ASiCService.storesSignature(ASiCService.java:398)
    at eu.europa.esig.dss.asic.signature.ASiCService.buildASiCContainer(ASiCService.java:298)
    at eu.europa.esig.dss.asic.signature.ASiCService.signDocument(ASiCService.java:177)
    at eu.europa.esig.dss.asic.signature.ASiCService.signDocument(ASiCService.java:84)
    at eu.europa.esig.dss.signature.AbstractTestSignature.sign(AbstractTestSignature.java:142)
    ...
Caused by: java.util.zip.ZipException: duplicate entry: META-INF/null
    at java.util.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:233)
    at eu.europa.esig.dss.asic.signature.ASiCService.createZipEntry(ASiCService.java:380)
    ... 36 more
```

```
eu.europa.esig.dss.DSSException: java.util.zip.ZipException: duplicate entry: META-INF/signatures001.xml
    at eu.europa.esig.dss.asic.signature.ASiCService.createZipEntry(ASiCService.java:382)
    at eu.europa.esig.dss.asic.signature.ASiCService.buildXAdES(ASiCService.java:716)
    at eu.europa.esig.dss.asic.signature.ASiCService.storesSignature(ASiCService.java:398)
    at eu.europa.esig.dss.asic.signature.ASiCService.buildASiCContainer(ASiCService.java:298)
    at eu.europa.esig.dss.asic.signature.ASiCService.signDocument(ASiCService.java:177)
    at eu.europa.esig.dss.asic.signature.ASiCService.signDocument(ASiCService.java:84)
    at eu.europa.esig.dss.signature.AbstractTestSignature.sign(AbstractTestSignature.java:142)
    ...
Caused by: java.util.zip.ZipException: duplicate entry: META-INF/signatures001.xml
    at java.util.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:233)
    at eu.europa.esig.dss.asic.signature.ASiCService.createZipEntry(ASiCService.java:380)
    ... 36 more
```

I also added a unit test for testing setting specific signature file name.
