### PR TITLE
Trimming asic container mime type string

### DIFF
--- a/dss-asic/src/main/java/eu/europa/esig/dss/asic/validation/ASiCContainerValidator.java
+++ b/dss-asic/src/main/java/eu/europa/esig/dss/asic/validation/ASiCContainerValidator.java
@@ -327,7 +327,7 @@ public class ASiCContainerValidator extends SignedDocumentValidator {
 			final InputStream inputStream = mimeType.openStream();
 			final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
 			IOUtils.copy(inputStream, byteArrayOutputStream);
-			final String mimeTypeString = byteArrayOutputStream.toString("UTF-8");
+			final String mimeTypeString = StringUtils.trim(byteArrayOutputStream.toString("UTF-8"));
 			final MimeType asicMimeType = MimeType.fromMimeTypeString(mimeTypeString);
 			return asicMimeType;
 		} catch(IOException e) {


### PR DESCRIPTION
This modification removes whitespace and line break characters from the beginning and end of container mime type string. This improves recognizability of asic containers.
