### PR TITLE
Fixed setting connection timeout on data loader

### DIFF
--- a/dss-service/src/main/java/eu/europa/esig/dss/client/http/commons/CommonsDataLoader.java
+++ b/dss-service/src/main/java/eu/europa/esig/dss/client/http/commons/CommonsDataLoader.java
@@ -213,7 +213,7 @@ public class CommonsDataLoader implements DataLoader, DSSNotifier {
 
 		final RequestConfig.Builder custom = RequestConfig.custom();
 		custom.setSocketTimeout(timeoutSocket);
-		custom.setConnectionRequestTimeout(timeoutConnection);
+		custom.setConnectTimeout(timeoutConnection);
 		final RequestConfig requestConfig = custom.build();
 		httpClientBuilder = httpClientBuilder.setDefaultRequestConfig(requestConfig);
 		httpClientBuilder.setConnectionManager(getConnectionManager());


### PR DESCRIPTION
This modification fixes setting connection timeout on the `CommonsDataLoader` and all the derived classes.

Previously the data loader timeout setting did not have any effect.
