### PR TITLE
Fixed setting encryption algorithm for asic containers

### DIFF
--- a/dss-asic/src/main/java/eu/europa/esig/dss/asic/signature/ASiCService.java
+++ b/dss-asic/src/main/java/eu/europa/esig/dss/asic/signature/ASiCService.java
@@ -580,6 +580,7 @@ public class ASiCService extends AbstractSignatureService<ASiCSignatureParameter
 		parameters.setDetachedContent(originalParameters.getDetachedContent());
 		parameters.setBLevelParams(originalParameters.bLevel());
 		parameters.setDigestAlgorithm(originalParameters.getDigestAlgorithm());
+		parameters.setEncryptionAlgorithm(originalParameters.getEncryptionAlgorithm());
 		parameters.setContentTimestampParameters(originalParameters.getContentTimestampParameters());
 		parameters.setContentTimestamps(originalParameters.getContentTimestamps());
 		parameters.setSignatureTimestampParameters(originalParameters.getSignatureTimestampParameters());


### PR DESCRIPTION
This modification fixes setting encryption algorithm for asic containers. 

Previously the `encryptionAlgorithm` parameter did not have any effect. It is now possible to use other encryption algorithms instead of default RSA, for example elliptic curves.
