### PR TITLE
Fixed handling OCSP revocation when reason is not given

### DIFF
--- a/dss-spi/src/main/java/eu/europa/esig/dss/x509/OCSPToken.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/x509/OCSPToken.java
@@ -108,15 +108,28 @@ public class OCSPToken extends RevocationToken {
 			final RevokedStatus revokedStatus = (RevokedStatus) certStatus;
 			status = false;
 			revocationDate = revokedStatus.getRevocationTime();
-			final int reasonId = revokedStatus.getRevocationReason();
-			final CRLReason crlReason = CRLReason.lookup(reasonId);
-			reason = crlReason.toString();
+            reason = getRevocationReason(revokedStatus);
 		} else if (certStatus instanceof UnknownStatus) {
 
 			if (logger.isInfoEnabled()) {
 				logger.info("OCSP status unknown");
 			}
 			reason = "OCSP status: unknown";
+		}
+	}
+
+	private String getRevocationReason(RevokedStatus revokedStatus) {
+		int reasonId = getRevocationReasonId(revokedStatus);
+		CRLReason crlReason = CRLReason.lookup(reasonId);
+		return crlReason.toString();
+	}
+
+    private int getRevocationReasonId(RevokedStatus revokedStatus) {
+		try {
+			return revokedStatus.getRevocationReason();
+		} catch (IllegalStateException e) {
+		logger.warn("OCSP Revocation reason is not available: " + e.getMessage());
+			return 0; //Zero means 'unspecified'
 		}
 	}
 


### PR DESCRIPTION
This modification fixes handling OCSP revocation when an OCSP response doesn't contain a reason. In that case the 'unspecified' reason is used.

Previously when an OCSP response did not contain a reason, then an exception was thrown.
